### PR TITLE
Add link to Interfaces-iteration manual section

### DIFF
--- a/doc/src/base/iterators.md
+++ b/doc/src/base/iterators.md
@@ -1,5 +1,7 @@
 # Iteration utilities
 
+For information on how to implement custom iterators, see the [Interfaces](https://docs.julialang.org/en/v1/manual/interfaces/#man-interface-iteration) section of the manual.
+
 ```@docs
 Base.Iterators.Stateful
 Base.Iterators.zip


### PR DESCRIPTION
It was unexpectedly difficult for me to find information on how to build custom iterators in Julia. The issue for me was that searching for iterators in Julia turns up the iteration utilities, [not the iteration interface](https://duckduckgo.com/?t=ffab&q=julia+iteration+&ia=web). It would have saved me a lot of time if there was a link in the iteration utilities to the interfaces, and that is the reason for this PR. 